### PR TITLE
Fix NImage type name collision

### DIFF
--- a/demo.py
+++ b/demo.py
@@ -19,7 +19,7 @@ app.use_app('pyqt5')
 def open_2Drgb():
     # opening a 2D RGB image:
     bma = load_bluemarble_image(large=False)
-    image = NImage(bma, 'BlueMarble', type=ImageType.RGB)
+    image = NImage(bma, 'BlueMarble', itype=ImageType.RGB)
     imgwin = ImageWindow(image, window_width=512, window_height=512)
     return imgwin
 
@@ -32,7 +32,7 @@ def open_2Dsc():
     array = np.empty((h, w), dtype=np.float32)
     array[:] = np.random.rand(h, w)
     array[-30:] = np.linspace(0, 1, w)
-    image = NImage(array, '2D1C', type=ImageType.Mono)
+    image = NImage(array, '2D1C', itype=ImageType.Mono)
     imgwin = ImageWindow(image, window_width=512, window_height=512)
     imgwin.set_cmap("viridis")
     return imgwin
@@ -47,7 +47,7 @@ def open_3Dsc():
     array = np.empty((h, w, d), dtype=np.float32)
     array[:] = np.exp(- X ** 2 - Y ** 2 - Z ** 2)  # * (1. + .5*(np.random.rand(h, w)-.5))
     # image[-30:] = np.linspace(0, 1, w)
-    image = NImage(array, '3D1C', type=ImageType.Mono)
+    image = NImage(array, '3D1C', itype=ImageType.Mono)
     imgwin = ImageWindow(image, window_width=512, window_height=512)
     imgwin.set_cmap("blues")
     return imgwin
@@ -63,7 +63,7 @@ def open_4dsc():
     array = np.empty((h, w, d, b), dtype=np.float32)
     array[:] = np.exp(- X ** 2 - Y ** 2 - Z ** 2 - C ** 2)  # * (1. + .5*(np.random.rand(h, w)-.5))
     # image[-30:] = np.linspace(0, 1, w)
-    image = NImage(array, '4D1C', type=ImageType.Mono)
+    image = NImage(array, '4D1C', itype=ImageType.Mono)
     imgwin = ImageWindow(image)
     imgwin.set_cmap("blues")
     return imgwin

--- a/napari/image/napari_image.py
+++ b/napari/image/napari_image.py
@@ -16,7 +16,4 @@ class NImage():
         return self.array.dtype
 
     def is_rgb(self):
-        return self.type == ImageType.RGB
-
-
-
+        return self.itype == ImageType.RGB

--- a/napari/image/napari_image.py
+++ b/napari/image/napari_image.py
@@ -4,11 +4,11 @@ from napari.image.image_type_enum import ImageType
 class NImage():
 
 
-    def __init__(self, array, name:str = '', type:ImageType = ImageType.Mono):
+    def __init__(self, array, name:str = '', itype:ImageType = ImageType.Mono):
 
         self.name     = name
         self.array    = array
-        self.type     = type
+        self.itype     = itype
         self.metadata = {}
 
 


### PR DESCRIPTION
I changed the input argument name for image type in the NImage constructor from ```type``` to ```itype``` to avoid collision with the built-in type function (see issue #16). I didn't see any tests, but I think I fixed any instances where the NImage constructor is used (just in demo.py?).